### PR TITLE
Fixed #11 from being too strict testing for use-onblur-not-onchange. …

### DIFF
--- a/src/rules/use-onblur-not-onchange.js
+++ b/src/rules/use-onblur-not-onchange.js
@@ -19,8 +19,9 @@ export default [{
         const disabled = trueish(props, 'aria-disabled');
         const readOnly = trueish(props, 'aria-readonly');
         const onChange = listensTo(props, 'onChange');
+        const onBlur = listensTo(props, 'onBlur');
 
-        return hidden || disabled || readOnly || !onChange;
+        return hidden || disabled || readOnly || !onChange || (onChange && onBlur);
     }
 }];
 
@@ -37,10 +38,13 @@ export const pass = [{
 }, {
     when: 'the element is aria-readonly',
     render: React => <input onChange={fn} aria-readonly />
+}, {
+    when: 'the `onChange` prop is present along with an `onBlur` prop',
+    render: React => <input onChange={fn} onBlur={fn} />
 }];
 
 export const fail = [{
-    when: 'the `onChange` prop is present',
+    when: 'the `onChange` prop is present without an `onBlur` prop',
     render: React => <input onChange={fn} />
 }];
 


### PR DESCRIPTION
… Now it should pass if onChange is used in addition to onBlur.  This more closely matches what's being tested for in [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/049136246a429302399bc46ec4a67b776a1ea87c/src/rules/use-onblur-not-onchange.js).