### PR TITLE
Update ReactDOM for react v16 compatibility

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -134,7 +134,7 @@ export default function (...args) {
     }
 
     // make sure ReactDOM is passed in in browser code
-    if (browser && !(ReactDOM && ReactDOM.version)) {
+    if (browser && !(ReactDOM && ReactDOM.findDOMNode)) {
         throw new Error('react-a11y: missing argument `ReactDOM`');
     }
 


### PR DESCRIPTION
It appears as is ReactDOM has been removed as of react v16. As a result, react-a11y throws the error "react-a11y: missing argument 'ReactDOM'". Updating the option check to look for `findDOMNode` instead.