### PR TITLE
Fix karma tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/reactjs/react-a11y/blob/latest/README.md",
   "bugs": "https://github.com/reactjs/react-a11y/issues",
   "scripts": {
-    "test": "npm run mocha # && npm run karma # commenting out karma until failing test is fixed",
+    "test": "npm run mocha && npm run karma",
     "docs": "mkdir -p docs/rules && babel-node mkdocs.js",
     "karma": "karma start --single-run --display-error-details",
     "mocha": "mocha --compilers js:babel-register --recursive -f '(browser)' -i",

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -127,7 +127,7 @@ export default class A11y {
 
                 const getDOMNode = () => {
                     // unpack the ref
-                    let DOMNode = null;
+                    let DOMNode = false;
                     if (typeof ref === 'string') {
                         DOMNode = _this.ReactDOM.findDOMNode(instance.refs[ref]); // TODO: replace use of findDOMNode
                     } else if ('node' in ref) {

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -127,19 +127,28 @@ export default class A11y {
 
                 // Cannot log a node reference until the component is in the DOM,
                 // so defer the call until componentDidMount or componentDidUpdate.
-                after.render(instance, () => {
-                    // unpack the ref
-                    let DOMNode = false;
+                const getDOMNode = () => {
+                    let DOMNode = null;
                     if (typeof ref === 'string') {
                         DOMNode = _this.ReactDOM.findDOMNode(instance.refs[ref]); // TODO: replace use of findDOMNode
                     } else if ('node' in ref) {
                         DOMNode = ref.node;
-                    } else {
-                        throw new Error('could not resolve ref');
                     }
-
+                    return DOMNode;
+                };
+                const DOMNode = getDOMNode();
+                if (DOMNode) {
                     reporter({ ...info, DOMNode });
-                });
+                } else {
+                    after.render(instance, () => {
+                        // unpack the ref
+                        const DOMNode = getDOMNode();
+                        if (!DOMNode) {
+                            throw new Error('could not resolve ref');
+                        }
+                        reporter({ ...info, DOMNode });
+                    });
+                }
             } else {
                 reporter(info);
             }

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -125,9 +125,8 @@ export default class A11y {
                 const _this = this;
                 const instance = owner._instance;
 
-                // Cannot log a node reference until the component is in the DOM,
-                // so defer the call until componentDidMount or componentDidUpdate.
                 const getDOMNode = () => {
+                    // unpack the ref
                     let DOMNode = null;
                     if (typeof ref === 'string') {
                         DOMNode = _this.ReactDOM.findDOMNode(instance.refs[ref]); // TODO: replace use of findDOMNode
@@ -138,10 +137,12 @@ export default class A11y {
                 };
                 const DOMNode = getDOMNode();
                 if (DOMNode) {
+                    // If we're already rendered, call reporter immediately
                     reporter({ ...info, DOMNode });
                 } else {
+                    // Cannot log a node reference until the component is in the DOM,
+                    // so defer the call until componentDidMount or componentDidUpdate.
                     after.render(instance, () => {
-                        // unpack the ref
                         const DOMNode = getDOMNode();
                         if (!DOMNode) {
                             throw new Error('could not resolve ref');

--- a/src/util/test-rules.js
+++ b/src/util/test-rules.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { expect } from 'chai';
 import A11y from '../a11y';
 
-export default function ({ React, ReactDOM, ruleDir, rules }) {
+export default function ({ React, ReactDOM, rules }) {
     describe('rules', () => {
         Object.keys(rules).forEach((rule) => {
             describe(rule, () => {

--- a/src/util/test-rules.js
+++ b/src/util/test-rules.js
@@ -14,7 +14,7 @@ export default function ({ React, ReactDOM, ruleDir, rules }) {
                     pass = [],
                     fail = [],
                     description
-                } = require(path.resolve(ruleDir, rule));
+                } = require(`../rules/${rule}`);
 
                 expect(description).to.be.a.string;
                 expect(pass).to.have.length.above(0);

--- a/test/browser/reporter.js
+++ b/test/browser/reporter.js
@@ -5,7 +5,7 @@ import { expect } from 'chai'
 
 const recieves = function (name, type) {
   it(`recieves \`${name}\``, done => {
-    
+
     const div = document.createElement('div')
     document.body.appendChild(div)
 

--- a/test/browser/reporter.js
+++ b/test/browser/reporter.js
@@ -5,7 +5,7 @@ import { expect } from 'chai'
 
 const recieves = function (name, type) {
   it(`recieves \`${name}\``, done => {
-
+    
     const div = document.createElement('div')
     document.body.appendChild(div)
 

--- a/test/rules.js
+++ b/test/rules.js
@@ -10,7 +10,6 @@ import testRules from '../src/util/test-rules';
 testRules({
     React,
     ReactDOM,
-    ruleDir: path.resolve(__dirname, '..', 'src', 'rules'),
     rules
 });
 


### PR DESCRIPTION
Fixes karma tests. Whatever bundler karma was using was unable to dynamically require files, so this semi-hard-codes the require path for the rules directory. This gives the bundler enough of a hint that it can correctly locate the rules files.

Once this issue was fixed, it became apparent that there was also another, separate issue. The failure handler was trying to determine whether a component had been rendered or not, but it seems like the logic wasn't quite right. The reporter call was being deferred by `after.render`, but `componentDidMount` had already fired. In other words, the failure handler was making the reporter call wait for something that had already happened. This issue could potentially cause some rule violations to never be reported.

This PR makes a minor change to call the reporter immediately if the component has already been rendered. I'm not entirely certain if this is the best method to go about this, so feel free to update as you see fit.