### PR TITLE
Prepare transfer of repository.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "release": "echo 'release command is not supported from this fork, see CONTRIBUTING.md for proper publishing workflow'",
     "preview-release": "echo 'preview-release command is not supported from this fork, see CONTRIBUTING.md for proper publishing workflow'"
   },
-  "authors": [
+  "contributors": [
     "Ryan Florence",
     "Todd Kloots",
-    "Angus Croll"
+    "Angus Croll",
+    "Romeo Van Snick <romeovs@gmail.com>",
+    "Erin Doyle"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Erin and his team are spending a lot of time and effort into this repository, and I feel me being the sole owner is only holding them back. Mainly because I do not have the time to be involved in this project anymore.

That's why I transferring this repo would be a good idea. And for that I want to set the attribution straight.

- Fixes the contributors field in `package.json` to be compliant with the [`npm` spec](https://docs.npmjs.com/files/package.json#people-fields-author-contributors).
- Adds Romeo Van Snick as a contributor.
- Adds Erin Doyle as a contributor (probably need to add some more people, from your team @erin-doyle).
